### PR TITLE
Fix animal tab crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# IDE files
+Source/.idea
+
 # =========================
 # Operating System Files
 # =========================

--- a/Source/BetterPawnControl.csproj
+++ b/Source/BetterPawnControl.csproj
@@ -15,7 +15,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Steam\steamapps\common\RimWorld\Mods\BetterPawnControl\Assemblies\</OutputPath>
+    <OutputPath Condition="Exists('..\..\Steam')">..\..\Steam\steamapps\common\RimWorld\Mods\BetterPawnControl\Assemblies\</OutputPath>
+    <OutputPath Condition="Exists('$(Home)\Library')">$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Mods\BetterPawnControl\Assemblies\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,10 +38,12 @@
     <Reference Include="Assembly-CSharp, Version=0.19.6814.14576, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>D:\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath Condition="Exists('$(Home)\Library')">$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Contents\Resources\Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HugsLib">
       <HintPath>D:\Steam\steamapps\common\RimWorld\Mods\HugsLib\Assemblies\HugsLib.dll</HintPath>
+      <HintPath  Condition="Exists('$(Home)\Library')">$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Mods\818773962\Assemblies\HugsLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -51,16 +54,20 @@
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>D:\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath Condition="Exists('$(Home)\Library')">$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Contents\Resources\Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>D:\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath Condition="Exists('$(Home)\Library')">$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Contents\Resources\Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
       <HintPath>D:\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath Condition="Exists('$(Home)\Library')">$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Contents\Resources\Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>D:\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath Condition="Exists('$(Home)\Library')">$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Contents\Resources\Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -101,6 +108,7 @@
     <VisualStudio AllowExistingFolder="true" />
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>xcopy "E:\BetterPawnControl\Assemblies\BetterPawnControl.dll" "D:\Steam\SteamApps\common\RimWorld\Mods\BetterPawnControl\v1.1\Assemblies" /y</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy "E:\BetterPawnControl\Assemblies\BetterPawnControl.dll" "D:\Steam\SteamApps\common\RimWorld\Mods\BetterPawnControl\v1.1\Assemblies" /y</PostBuildEvent>
+    <PostBuildEvent Condition="Exists('$(Home)\Library')">cp -f "$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Mods\BetterPawnControl\Assemblies\BetterPawnControl.dll" "$(Home)\Library\Application Support\Steam\steamapps\common\RimWorld\RimWorldMac.app\Mods\BetterPawnControl\v1.1\Assemblies\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Source/Managers/AnimalManager.cs
+++ b/Source/Managers/AnimalManager.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using System;
+using Verse;
 using RimWorld;
 using System.Collections.Generic;
 
@@ -45,7 +46,7 @@ namespace BetterPawnControl
                 //find animal on the current zone
                 AnimalLink animalLink =
                     AnimalManager.links.Find(
-                        x => p.Equals(x.animal) &&
+                        x => x != null && p.Equals(x.animal) &&
                         x.zone == AnimalManager.GetActivePolicy().id &&
                         x.mapId == currentMap);
 
@@ -81,6 +82,7 @@ namespace BetterPawnControl
         /// </summary>
         internal static void CleanDeadAnimals(List<Pawn> pawns)
         {
+            AnimalManager.links.RemoveAll(l => l == null);
             for (int i = 0; i < AnimalManager.links.Count; i++)
             {
                 AnimalLink pawn = AnimalManager.links[i];
@@ -105,9 +107,9 @@ namespace BetterPawnControl
             int currentMap = Find.CurrentMap.uniqueID;
 
             //get all links from the current map
-            mapLinks = links.FindAll(x => x.mapId == currentMap);
+            mapLinks = links.FindAll(x => x != null && x.mapId == currentMap);
             //get all links from the selected zone
-            zoneLinks = mapLinks.FindAll(x => x.zone == policy.id);
+            zoneLinks = mapLinks.FindAll(x => x != null &&  x.zone == policy.id);
 
             foreach (Pawn p in pawns)
             {
@@ -138,11 +140,15 @@ namespace BetterPawnControl
             List<AnimalLink> mapLinks = null;
             List<AnimalLink> zoneLinks = null;
             int currentMap = Find.CurrentMap.uniqueID;
+            if (links == null) throw new ArgumentNullException(nameof(links));
+            if (policy == null) throw new ArgumentNullException(nameof(policy));
 
             //get all links from the current map
-            mapLinks = links.FindAll(x => x.mapId == currentMap);
+            mapLinks = links.FindAll(l => l != null && l.mapId == currentMap);
             //get all links from the selected zone
-            zoneLinks = mapLinks.FindAll(x => x.zone == policy.id);
+            zoneLinks = mapLinks.FindAll(ml => ml != null && ml.zone == policy.id);
+            var brokenLinks = links.FindAll(x => x == null).CountAllowNull();
+            if (brokenLinks > 0) Log.Warning("[BPC] AnimalManager.UpdateState was given " + brokenLinks + " dead links");
 
             foreach (Pawn p in pawns)
             {
@@ -224,7 +230,7 @@ namespace BetterPawnControl
                 + "] ###");
             foreach (AnimalLink l in AnimalManager.links)
             {
-                Log.Message("[BPC]\t" + l.ToString());
+                Log.Message("[BPC]\t" + l);
             }
 
             Log.Message(spacer);


### PR DESCRIPTION
- Configures the project to build on OSX (conditionally check file paths, etc)
- Add defensive handling for null AnimalLink references in AnimalManager

Fix #20

Feel free to cherry-pick just the fix if you don't want the project setup changes. I haven't done C# before so it's possible I don't have it set up quite right, but I was able to run the app and confirm the fix with these changes.