### PR TITLE
feat: be 'autocleaner' compatible by allowing pawns without timetables

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -21,6 +21,7 @@ https://ludeon.com/forums/index.php?topic=26618.0
 Mod Integrations List:
 - Combat extended
 - Children, school and learning
+- Autocleaner
 
 Mod Incompatibility List:
 - Animal Tab 

--- a/Source/Base/RestrictLink.cs
+++ b/Source/Base/RestrictLink.cs
@@ -19,7 +19,10 @@ namespace BetterPawnControl
             this.zone = link.zone;
             this.colonist = link.colonist;
             this.area = link.area;
-            this.schedule = new List<TimeAssignmentDef>(link.schedule);
+            if (link.schedule != null)
+            {
+                this.schedule = new List<TimeAssignmentDef>(link.schedule);
+            }
             this.mapId = link.mapId;
         }
 
@@ -28,7 +31,10 @@ namespace BetterPawnControl
             this.zone = zone;
             this.colonist = colonist;
             this.area = area;
-            this.schedule = new List<TimeAssignmentDef>(times);
+            if (times != null)
+            {
+                this.schedule = new List<TimeAssignmentDef>(times);
+            }
             this.mapId = mapId;
         }
 
@@ -52,7 +58,7 @@ namespace BetterPawnControl
             Scribe_References.Look<Pawn>(ref colonist, "colonist");
             Scribe_References.Look<Area>(ref area, "area");
             Scribe_Collections.Look(ref schedule, "schedule", LookMode.Def);
-            if (Scribe.mode == LoadSaveMode.ResolvingCrossRefs && schedule == null)
+            if (Scribe.mode == LoadSaveMode.ResolvingCrossRefs && schedule == null && colonist.timetable != null)
             {
                 //this means the current save does not contain schedule data. So let's start new
                 this.schedule = new List<TimeAssignmentDef>(colonist.timetable.times);

--- a/Source/Managers/RestrictManager.cs
+++ b/Source/Managers/RestrictManager.cs
@@ -63,7 +63,10 @@ namespace BetterPawnControl
                 {
                     //colonist found! save 
                     link.area = p.playerSettings.AreaRestriction;
-                    RestrictManager.CopySchedule(p.timetable.times, link.schedule);
+                    if (p.timetable != null)
+                    {
+                        RestrictManager.CopySchedule(p.timetable.times, link.schedule);
+                    }
                 }
                 else
                 {
@@ -73,7 +76,7 @@ namespace BetterPawnControl
                             activePolicyId,
                             p,
                             p.playerSettings.AreaRestriction,
-                            p.timetable.times,
+                            p.timetable != null ? p.timetable.times : null,
                             currentMap));
                 }
             }
@@ -186,7 +189,10 @@ namespace BetterPawnControl
                     if (l.colonist != null && l.colonist.Equals(p))
                     {
                         p.playerSettings.AreaRestriction = l.area;
-                        RestrictManager.CopySchedule(l.schedule, p.timetable.times);
+                        if (l.schedule != null && p.timetable != null)
+                        {
+                            RestrictManager.CopySchedule(l.schedule, p.timetable.times);
+                        }
                         p.Tick();
                     }
                 }


### PR DESCRIPTION
This treats the pawns' timetables as optional, allowing them to be `null`. As a result autocleaners, which don't have a timetable, no longer cause a null pointer exception when trying to close the schedule tab.

I've tested this and confirmed it to work with RimWorld 1.2.2753 and Autocleaner 1.2 (AUTOMATIC1111/Autocleaner@c115e0b6dd279e3adefbe8c9332fb09c4d4c7d1b).

The exception that gets thrown without this change when (a) you have the autocleaner mod and an activated autocleaner and (b) try to close the schedule tab:
```
Root level exception in OnGUI(): System.NullReferenceException: Object reference not set to an instance of an object
  at BetterPawnControl.RestrictManager.SaveCurrentState (System.Collections.Generic.List`1[T] pawns) [0x000bf] in <58c5b65fc83547e7afaa09327dc70563>:0 
  at BetterPawnControl.MainTabWindow_Restrict_Policies.PreClose () [0x00026] in <58c5b65fc83547e7afaa09327dc70563>:0 
  at Verse.WindowStack.TryRemove (Verse.Window window, System.Boolean doCloseSound) [0x00047] in <d72310b4d8f64d25aee502792b58549f>:0 
  at RimWorld.MainTabsRoot.ToggleTab (RimWorld.MainButtonDef newTab, System.Boolean playSound) [0x00056] in <d72310b4d8f64d25aee502792b58549f>:0 
  at RimWorld.MainButtonWorker_ToggleTab.Activate () [0x00005] in <d72310b4d8f64d25aee502792b58549f>:0 
  at RimWorld.MainButtonWorker.InterfaceTryActivate () [0x0004d] in <d72310b4d8f64d25aee502792b58549f>:0 
  at (wrapper dynamic-method) RimWorld.MainButtonWorker.RimWorld.MainButtonWorker.DoButton_Patch0(RimWorld.MainButtonWorker,UnityEngine.Rect)
  at RimWorld.MainButtonsRoot.DoButtons () [0x0010c] in <d72310b4d8f64d25aee502792b58549f>:0 
  at RimWorld.MainButtonsRoot.MainButtonsOnGUI () [0x0000e] in <d72310b4d8f64d25aee502792b58549f>:0 
  at RimWorld.UIRoot_Play.UIRootOnGUI () [0x00037] in <d72310b4d8f64d25aee502792b58549f>:0 
  at (wrapper dynamic-method) Verse.Root.Verse.Root.OnGUI_Patch1(Verse.Root)
(Filename: C:\buildslave\unity\build\Runtime/Export/Debug/Debug.bindings.h Line: 35)
```