### PR TITLE
Change compatibility check for Work Tab.

### DIFF
--- a/Source/Helpers/Widget_WorkTab.cs
+++ b/Source/Helpers/Widget_WorkTab.cs
@@ -29,7 +29,7 @@ namespace BetterPawnControl
 
         static Widget_WorkTab()
         {
-            var isModActive = LoadedModManager.RunningMods.Any(mod => mod.Name == "Work Tab");
+            var isModActive = LoadedModManager.RunningMods.Any(mod => mod.Name.Contains("Work Tab"));
             if (!isModActive)
                 return;
 


### PR DESCRIPTION
Modify the compatibility check for Work Tab to look for string.Contains() instead of exact match.

This addresses issues with forked versions of Work Tab.