### PR TITLE
loadBefore Achtung

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -40,6 +40,9 @@ Mod Integrations List:
 			<downloadUrl>https://github.com/pardeike/HarmonyRimWorld/releases/latest</downloadUrl>
 		</li>
 	</modDependencies>
+	<loadBefore>
+  		<li>brrainz.achtung</li>
+	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>
 		<li>Ludeon.RimWorld</li>


### PR DESCRIPTION
**Achtung Compatibility**
Fixes compatibility bug with a popular mod called Achtung, which adds "Rescue" / "Rescuing" workTypeDef, which can break Better Pawn Control tab - it occurs when Achtung is above in the load order.

**More Info:**
- Acthung, has a mod option checkbox 'Rescue' work priority column . This is enabled by default. If you saved the game (meaning you've stored the rescue values), then somehow this option becomes disabled (or you removed Acthung), you will get ref errors around rescuing WorkTypeDef.

**Impact:**
Medium to High - 2 variants of this bug depending on config when user saves game:
1) Leaves you without Rescue in the work tab + reference errors
2) Can completely breaks the Better Pawn Control tab & causes error spam

**Changes:**
Making these changes, I have managed to restore a test save with errors to functioning state. 
PR created to help defend wider users from this problem