### PR TITLE
Make the default set by this mod visible in vanilla

### DIFF
--- a/Source/Patches/Dialog_ManageApparelPolicies_GetDefaultPolicy.cs
+++ b/Source/Patches/Dialog_ManageApparelPolicies_GetDefaultPolicy.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace BetterPawnControl.Patches
+{
+    [HarmonyPatch(typeof(Dialog_ManageApparelPolicies), "GetDefaultPolicy")]
+    static class Dialog_ManageApparelPolicies_GetDefaultPolicy
+    {
+        static void Postfix(ref ApparelPolicy __result)
+        {
+            __result = AssignManager.DefaultOutfit;
+        }
+        
+    }
+}

--- a/Source/Patches/Dialog_ManageDrugPolicies_GetDefaultPolicy.cs
+++ b/Source/Patches/Dialog_ManageDrugPolicies_GetDefaultPolicy.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace BetterPawnControl.Patches
+{
+    [HarmonyPatch(typeof(Dialog_ManageDrugPolicies), "GetDefaultPolicy")]
+    static class Dialog_ManageDrugPolicies_GetDefaultPolicy
+    {
+        static void Postfix(ref DrugPolicy __result)
+        {
+            __result = AssignManager.DefaultDrugPolicy;
+        }
+
+    }
+}

--- a/Source/Patches/Dialog_ManageFoodPolicies_GetDefaultPolicy.cs
+++ b/Source/Patches/Dialog_ManageFoodPolicies_GetDefaultPolicy.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace BetterPawnControl.Patches
+{
+    [HarmonyPatch(typeof(Dialog_ManageFoodPolicies), "GetDefaultPolicy")]
+    static class Dialog_ManageFoodPolicies_GetDefaultPolicy
+    {
+        static void Postfix(ref FoodPolicy __result)
+        {
+            __result = AssignManager.DefaultFoodPolicy;
+        }
+
+    }
+}

--- a/Source/Patches/Dialog_ManageReadingPolicies_GetDefaultPolicy.cs
+++ b/Source/Patches/Dialog_ManageReadingPolicies_GetDefaultPolicy.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace BetterPawnControl.Patches
+{
+    [HarmonyPatch(typeof(Dialog_ManageReadingPolicies), "GetDefaultPolicy")]
+    static class Dialog_ManageReadingPolicies_GetDefaultPolicy
+    {
+        static void Postfix(ref ReadingPolicy __result)
+        {
+            __result = AssignManager.DefaultReadingPolicy;
+        }
+
+    }
+}


### PR DESCRIPTION
Make the default set by this mod visible in vanilla dialogs (* and (default) text)

for example, if I set Novel as default reading policy using this mod, this is reflected in game's dialog

![immagine](https://github.com/user-attachments/assets/21e01e29-59be-4a94-b788-3be39f6609c7)

It's a simple patching of GetDefaultPolicy for Dialog_Manage[Apparel/Food/Drug/Reading]Policies
